### PR TITLE
Improve explicit imports hygiene

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,8 +12,9 @@ RecipesBase = "0.7, 0.8, 1.0"
 julia = "1.6"
 
 [extras]
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Plots"]
+test = ["ExplicitImports", "Plots", "Test"]

--- a/src/DimensionalPlotRecipes.jl
+++ b/src/DimensionalPlotRecipes.jl
@@ -1,7 +1,7 @@
 module DimensionalPlotRecipes
 
-using RecipesBase
-using LinearAlgebra
+using RecipesBase: RecipesBase, @recipe
+using LinearAlgebra: LinearAlgebra, norm
 
 # Splits a complex matrix to its real and complex parts
 # Reals defaults solid, imaginary defaults dashed

--- a/test/explicit_imports.jl
+++ b/test/explicit_imports.jl
@@ -1,0 +1,8 @@
+using ExplicitImports
+using DimensionalPlotRecipes
+using Test
+
+@testset "ExplicitImports" begin
+    @test check_no_implicit_imports(DimensionalPlotRecipes) === nothing
+    @test check_no_stale_explicit_imports(DimensionalPlotRecipes) === nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,8 @@
 using DimensionalPlotRecipes, Test
 
+# Test explicit imports hygiene
+include("explicit_imports.jl")
+
 A = rand(5, 2) .+ im .* rand(5, 2)
 t = range(0, stop = 1, length = 5)
 


### PR DESCRIPTION
## Summary
- Fixed implicit imports in `src/DimensionalPlotRecipes.jl` by making imports explicit
- Added ExplicitImports.jl tests to ensure import hygiene is maintained
- All tests pass including new ExplicitImports checks

## Changes Made

### src/DimensionalPlotRecipes.jl
- Changed `using RecipesBase` → `using RecipesBase: RecipesBase, @recipe`
- Changed `using LinearAlgebra` → `using LinearAlgebra: LinearAlgebra, norm`

This makes the imports explicit and avoids relying on all exports from these packages.

### test/explicit_imports.jl (new file)
Added tests to verify:
- No implicit imports in the package
- No stale explicit imports (unused imports)

### test/runtests.jl
- Added `include("explicit_imports.jl")` to run import hygiene tests

### Project.toml
- Added ExplicitImports to `[extras]` and `[targets]` for test dependencies

## Test Results
All tests pass:
```
Test Summary:   | Pass  Total  Time
ExplicitImports |    2      2  1.4s
     Testing DimensionalPlotRecipes tests passed
```

@ChrisRackauckas - This PR ensures the package follows best practices for explicit imports and prevents future import hygiene issues through automated testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)