### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
-      - "/test"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -11,22 +11,11 @@ on:
     paths-ignore:
       - 'docs/**'
 jobs:
-  test:
+  downgrade:
     if: false
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,5 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## What this does

Converts the remaining inline CI workflows to the centralized reusable workflows in `SciML/.github`, all pinned at `@v1` with `secrets: "inherit"`.

### Converted (inline -> central caller)
- **FormatCheck.yml**: `fredrikekre/runic-action` -> `runic.yml@v1`
- **SpellCheck.yml**: `crate-ci/typos` -> `spellcheck.yml@v1`
- **Downgrade.yml**: inline downgrade job -> `downgrade.yml@v1`, preserving `if: false`, `julia-version: 1.10`, `skip: Pkg,TOML`, and `allow-reresolve: false`. (The inline `downgrade_mode: alldeps` is the julia-downgrade-compat default, so behavior is preserved.)

### Unchanged
- **Tests.yml**: already a `tests.yml@v1` caller with `secrets: "inherit"` and matrix `version: [1, lts, pre]`.
- **TagBot.yml**: left as-is.

### Cleanup
- **dependabot.yml**: removed the `crate-ci/typos` version ignore (no longer needed now that typos runs via the centralized caller). Narrowed the `julia` block to `/` only, since there is no `test/Project.toml` (test deps live in the root `[extras]`/`[targets]`).
- No `CompatHelper.yml` present.

### Verification
- Ran Runic v1.7.0 in place: no source changes (repo was already Runic-clean from the inline check).
- Ran `typos` v1.47.0 (matching the central spellcheck pin): exit 0, clean. No prose edits needed; existing `.typos.toml` retained.
- Validated all changed YAML with `yaml.safe_load`.

### Note on branch protection
Check names change with the move to reusable workflows (e.g. the Runic job now reports under the reusable workflow). If branch-protection required status checks are configured, they may need updating to the new check names.

Typos fixed: 0. Runic formatting applied: no (already clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)