### PR TITLE
Downgrade: raise RecipesBase compat floor to 1.0 (incompatible with Plots 1 below)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 ExplicitImports = "1"
 LinearAlgebra = "1"
 Plots = "1"
-RecipesBase = "0.8, 1.0"
+RecipesBase = "1.0"
 Test = "1"
 julia = "1.10"
 


### PR DESCRIPTION
The MINIMUM-VERSION (downgrade) job fails. Reproduced locally on Julia 1.10 (the LTS downgrade floor); the conflict is:

```
Unsatisfiable requirements detected for package Plots [91a5bcdd]:
 Plots [91a5bcdd] log:
 ├─restricted to versions 1 by project, leaving only versions: 1.0.0-1.41.6
 └─restricted by compatibility requirements with RecipesBase [3cdcf5f2]
   to versions: 0.29.0-0.29.9 or uninstalled — no versions left
     └─RecipesBase restricted to versions 0.8.0 by an explicit requirement
```

**Why the old floor was impossible**

- At the downgrade minimum `RecipesBase` is pinned to its floor `0.8.0` (compat `RecipesBase = "0.8, 1.0"`), and the test dep `Plots` is pinned to its floor `1.0.0` (compat `Plots = "1"`).
- In the registry, every `Plots 1.x` requires `RecipesBase = "1"` (`Plots 1.0-1.23 -> RecipesBase 1`). `RecipesBase 0.8.x` is only co-installable with the pre-1.0 `Plots 0.29.x`.
- So `RecipesBase 0.8.0` and `Plots 1` have an empty intersection -> Unsatisfiable. Bumping the *Plots* floor cannot help, since no `Plots >= 1` supports RecipesBase 0.8.

**Fix**

Raise the lower bound: `RecipesBase = "0.8, 1.0"` -> `RecipesBase = "1.0"`. 1.0 is the smallest RecipesBase co-installable with Plots 1. The `@recipe` API this package uses is unchanged between RecipesBase 0.8 and 1.0; no upper bound lowered, no test logic touched.

**Resolve verification (local, Julia 1.10 LTS)**

Mimicking `julia-downgrade-compat --min` (all `[compat]` entries pinned to their lower bounds):
- floor `RecipesBase = 0.8` -> `Unsatisfiable` (reproduces CI).
- floor `RecipesBase = 1.0` -> `RESOLVE SUCCEEDED` (installs Plots v1.23.6, exit 0).

Resolution only — the full test suite was not run locally; PR CI confirms.

Ignore until reviewed by @ChrisRackauckas.