### PR TITLE
Use SciMLTesting v1.2 (folder-based run_tests)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,8 @@ ExplicitImports = "1"
 LinearAlgebra = "1"
 Plots = "1"
 RecipesBase = "0.8, 1.0"
+SafeTestsets = "0.1, 1"
+SciMLTesting = "1"
 Test = "1"
 julia = "1.10"
 
@@ -20,7 +22,9 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ExplicitImports", "JET", "Plots", "Test"]
+test = ["Aqua", "ExplicitImports", "JET", "Plots", "SafeTestsets", "SciMLTesting", "Test"]

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -2,6 +2,8 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DimensionalPlotRecipes = "c619ae07-58cd-5f6d-b883-8f17bd6a98f9"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
@@ -10,5 +12,7 @@ DimensionalPlotRecipes = {path = "../.."}
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
+SafeTestsets = "0.1, 1"
+SciMLTesting = "1"
 Test = "1"
 julia = "1.10"

--- a/test/recipes.jl
+++ b/test/recipes.jl
@@ -1,0 +1,13 @@
+using DimensionalPlotRecipes
+using Plots
+
+A = rand(5, 2) .+ im .* rand(5, 2)
+t = range(0, stop = 1, length = 5)
+
+plot(t, A)
+
+t = range(0, stop = 1, length = 5)
+plot(t, A)
+plot(t, A, transformation = :split3D)
+plot(t, A, transformation = :modulus)
+plot(t, A, transformation = :modulus2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,24 +1,2 @@
-using DimensionalPlotRecipes, Test
-
-const GROUP = get(ENV, "GROUP", "All")
-
-if GROUP == "All" || GROUP == "Core"
-    # Test explicit imports hygiene
-    include("explicit_imports.jl")
-
-    A = rand(5, 2) .+ im .* rand(5, 2)
-    t = range(0, stop = 1, length = 5)
-
-    using Plots
-    plot(t, A)
-
-    t = range(0, stop = 1, length = 5)
-    plot(t, A)
-    plot(t, A, transformation = :split3D)
-    plot(t, A, transformation = :modulus)
-    plot(t, A, transformation = :modulus2)
-end
-
-if GROUP == "QA"
-    include(joinpath("qa", "qa.jl"))
-end
+using SciMLTesting
+run_tests()


### PR DESCRIPTION
Converts the test suite to the SciMLTesting v1.2 folder-based `run_tests()` model.

`test/runtests.jl` is now just:

```julia
using SciMLTesting
run_tests()
```

Group routing is derived from the folder layout + `test/test_groups.toml` (unchanged):

- **Core** = top-level `test/*.jl` (`explicit_imports.jl` + `recipes.jl`, the latter extracted from the old inline plotting smoke test in `runtests.jl`).
- **QA** = `test/qa/` with its existing per-group `Project.toml` sub-env (Aqua + JET).
- **All** = Core (the only non-QA group), matching the previous `GROUP == "All" || GROUP == "Core"` behavior.

Deps: added `SciMLTesting` + `SafeTestsets` to the root `[extras]`/`[targets].test`/`[compat]` and to `test/qa/Project.toml`. `test/test_groups.toml` is unchanged. Per-GROUP file sets verified identical to master via folder discovery.

This supersedes the earlier v1.1.0 explicit-args rollout on this branch.

Ignore until reviewed by @ChrisRackauckas.
