### PR TITLE
Canonicalize test units with @safetestset

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ ExplicitImports = "1"
 LinearAlgebra = "1"
 Plots = "1"
 RecipesBase = "0.8, 1.0"
+SafeTestsets = "0.1, 1"
 Test = "1"
 julia = "1.10"
 
@@ -20,7 +21,8 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ExplicitImports", "JET", "Plots", "Test"]
+test = ["Aqua", "ExplicitImports", "JET", "Plots", "SafeTestsets", "Test"]

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -2,6 +2,7 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DimensionalPlotRecipes = "c619ae07-58cd-5f6d-b883-8f17bd6a98f9"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
@@ -10,5 +11,6 @@ DimensionalPlotRecipes = {path = "../.."}
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
+SafeTestsets = "0.1, 1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,6 +1,7 @@
-using DimensionalPlotRecipes, Aqua, JET, Test
+using SafeTestsets
 
-@testset "Aqua" begin
+@safetestset "Aqua" begin
+    using DimensionalPlotRecipes, Aqua, Test
     # deps_compat and piracies are genuine findings tracked in
     # https://github.com/SciML/DimensionalPlotRecipes.jl/issues/50
     Aqua.test_all(DimensionalPlotRecipes; deps_compat = false, piracies = false)
@@ -8,6 +9,7 @@ using DimensionalPlotRecipes, Aqua, JET, Test
     @test_broken false  # Aqua piracies: @recipe-generated apply_recipe on RecipesBase types — see https://github.com/SciML/DimensionalPlotRecipes.jl/issues/50
 end
 
-@testset "JET" begin
+@safetestset "JET" begin
+    using DimensionalPlotRecipes, JET, Test
     @test_broken false  # JET: no matching method `is_key_supported(::Symbol)` in apply_recipe — see https://github.com/SciML/DimensionalPlotRecipes.jl/issues/50
 end

--- a/test/recipes.jl
+++ b/test/recipes.jl
@@ -1,0 +1,13 @@
+using DimensionalPlotRecipes
+using Plots
+
+A = rand(5, 2) .+ im .* rand(5, 2)
+t = range(0, stop = 1, length = 5)
+
+plot(t, A)
+
+t = range(0, stop = 1, length = 5)
+plot(t, A)
+plot(t, A, transformation = :split3D)
+plot(t, A, transformation = :modulus)
+plot(t, A, transformation = :modulus2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,22 +1,12 @@
-using DimensionalPlotRecipes, Test
+using DimensionalPlotRecipes, SafeTestsets, Test
 
 const GROUP = get(ENV, "GROUP", "All")
 
 if GROUP == "All" || GROUP == "Core"
     # Test explicit imports hygiene
-    include("explicit_imports.jl")
+    @safetestset "Explicit Imports" include("explicit_imports.jl")
 
-    A = rand(5, 2) .+ im .* rand(5, 2)
-    t = range(0, stop = 1, length = 5)
-
-    using Plots
-    plot(t, A)
-
-    t = range(0, stop = 1, length = 5)
-    plot(t, A)
-    plot(t, A, transformation = :split3D)
-    plot(t, A, transformation = :modulus)
-    plot(t, A, transformation = :modulus2)
+    @safetestset "Recipes" include("recipes.jl")
 end
 
 if GROUP == "QA"


### PR DESCRIPTION
## What

Canonicalize the test suite so each independent test unit runs in its own module via `@safetestset` (isolation between units + world-age safety), matching the canonical OrdinaryDiffEq structure.

### Core group
- The explicit-imports hygiene check is now `@safetestset "Explicit Imports" include("explicit_imports.jl")`.
- The bare top-level `plot(...)` recipe exercises (which had no assertions — they confirm the recipe runs without error) moved into a new self-contained `test/recipes.jl`, loaded via `@safetestset "Recipes" include("recipes.jl")`.

### QA group
- The plain `@testset "Aqua"` and `@testset "JET"` units in `test/qa/qa.jl` become `@safetestset`, each carrying its own `using` imports. The `Aqua.test_all(...)` call and the `@test_broken` entries are preserved verbatim.

### Deps
- `SafeTestsets` added to the root `[extras]` / `[targets].test` / `[compat]` (`SafeTestsets = "0.1, 1"`), and to `test/qa/Project.toml` (the QA group activates its own project).

## Behavior-preserving
Same tests run under the same `GROUP` dispatch, same assertions (including the `@test_broken` entries). The `GROUP` ladder / runtests structure is otherwise unchanged.

## Verification (local, Julia 1.11)
- `GROUP=Core Pkg.test()` -> `Explicit Imports` 2/2 pass; `Recipes` runs (0 assertions, as before). Passed.
- `GROUP=QA Pkg.test()` -> `Aqua` 6 pass / 2 broken; `JET` 1 broken. Passed.
- Runic-clean; all changed files parse cleanly.

---

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)