### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,18 +8,18 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 
 [compat]
-ExplicitImports = "1"
+Aqua = "0.8"
+JET = "0.9,0.10,0.11"
 LinearAlgebra = "1"
 Plots = "1"
 RecipesBase = "1.0"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
@@ -27,4 +27,4 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ExplicitImports", "JET", "Plots", "SafeTestsets", "SciMLTesting", "Test"]
+test = ["Aqua", "JET", "Plots", "SafeTestsets", "SciMLTesting", "Test"]

--- a/test/explicit_imports.jl
+++ b/test/explicit_imports.jl
@@ -1,8 +1,0 @@
-using ExplicitImports
-using DimensionalPlotRecipes
-using Test
-
-@testset "ExplicitImports" begin
-    @test check_no_implicit_imports(DimensionalPlotRecipes) === nothing
-    @test check_no_stale_explicit_imports(DimensionalPlotRecipes) === nothing
-end

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -2,6 +2,7 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DimensionalPlotRecipes = "c619ae07-58cd-5f6d-b883-8f17bd6a98f9"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -12,7 +13,8 @@ DimensionalPlotRecipes = {path = "../.."}
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
+RecipesBase = "1"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,13 +1,10 @@
-using DimensionalPlotRecipes, Aqua, JET, Test
+using SciMLTesting, DimensionalPlotRecipes, JET, Test
+using RecipesBase: apply_recipe
 
-@testset "Aqua" begin
-    # deps_compat and piracies are genuine findings tracked in
-    # https://github.com/SciML/DimensionalPlotRecipes.jl/issues/50
-    Aqua.test_all(DimensionalPlotRecipes; deps_compat = false, piracies = false)
-    @test_broken false  # Aqua deps_compat: root Project.toml lacks compat for Aqua/JET extras — see https://github.com/SciML/DimensionalPlotRecipes.jl/issues/50
-    @test_broken false  # Aqua piracies: @recipe-generated apply_recipe on RecipesBase types — see https://github.com/SciML/DimensionalPlotRecipes.jl/issues/50
-end
-
-@testset "JET" begin
-    @test_broken false  # JET: no matching method `is_key_supported(::Symbol)` in apply_recipe — see https://github.com/SciML/DimensionalPlotRecipes.jl/issues/50
-end
+# The @recipe-generated method defines RecipesBase.apply_recipe but is owned by
+# DimensionalPlotRecipes, so Aqua flags it as piracy; treat_as_own clears it.
+run_qa(
+    DimensionalPlotRecipes;
+    explicit_imports = true,
+    aqua_kwargs = (; piracies = (; treat_as_own = [apply_recipe])),
+)


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts `test/qa/qa.jl` from the hand-rolled `Aqua.test_all`/JET `@test_broken` body onto the SciMLTesting 1.6.0 `run_qa` form, with **ExplicitImports enabled**.

### ExplicitImports findings (`explicit_imports = true`)
All six checks pass with **no** ignore-lists and **no** `ei_broken`:
- `no_implicit_imports` ✅
- `no_stale_explicit_imports` ✅
- `all_explicit_imports_via_owners` ✅
- `all_qualified_accesses_via_owners` ✅
- `all_qualified_accesses_are_public` ✅
- `all_explicit_imports_are_public` ✅

The `src` is minimal and already fully-explicit (`using RecipesBase: RecipesBase, @recipe`, `using LinearAlgebra: LinearAlgebra, norm`).

### The three #50 `@test_broken` findings — all FIXED (none left broken)
1. **Aqua `deps_compat`** — the root `Project.toml` was missing `[compat]` entries for the test-only `Aqua`/`JET` extras. Added them. (Fix, not suppression.)
2. **Aqua `piracies`** — the `@recipe`-generated `RecipesBase.apply_recipe` method is owned by `DimensionalPlotRecipes`; cleared with `aqua_kwargs = (; piracies = (; treat_as_own = [apply_recipe]))`.
3. **JET `is_key_supported(::Symbol)`** — that report lives in `RecipesBase`, not `DimensionalPlotRecipes`. `run_qa`'s default `jet_kwargs = (; target_modules = (pkg,), mode = :typo)` scopes it out, so `JET.test_package` runs **green** (no `jet_broken`).

This resolves all of #50.

### Deps
- Bump `SciMLTesting` `[compat]` floor to `"1.6"` (root + `test/qa`).
- Add `RecipesBase` to the `test/qa` sub-env (for the `apply_recipe` reference).
- Drop `ExplicitImports` from the root `[extras]`/`[targets].test` (now transitive via SciMLTesting) and remove the now-redundant Core `test/explicit_imports.jl`; ExplicitImports runs inside the QA group via `run_qa`.

### Local verification (released SciMLTesting 1.6.0, resolved by Pkg — no dev-from-branch)
```
Julia 1.10 (lts):  QA/qa.jl | Pass 18  Total 18   (0 broken / 0 fail / 0 error)
Julia 1.11 ("1"):  QA/qa.jl | Pass 18  Total 18   (0 broken / 0 fail / 0 error)
Core (1.10):       Core/recipes.jl green
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)