### PR TITLE
Release prep: bump DimensionalPlotRecipes to 1.4.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DimensionalPlotRecipes"
 uuid = "c619ae07-58cd-5f6d-b883-8f17bd6a98f9"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
Patch release for the accumulated docstring/QA/test scaffolding changes since v1.4.0 (SciMLTesting compat bump and QA API-docs check enablement; no source changes).